### PR TITLE
_deferred and promise should not be accessed outside the mixin

### DIFF
--- a/packages/ember-data/lib/system/mixins/load_promise.js
+++ b/packages/ember-data/lib/system/mixins/load_promise.js
@@ -7,17 +7,12 @@ var LoadPromise = Ember.Mixin.create(Evented, Deferred, {
   init: function() {
     this._super.apply(this, arguments);
 
-    var deferred, promise;
-
-    deferred = get(this, '_deferred');
-    promise = deferred.promise;
-
-    this.one('didLoad', function() {
-      run(this, 'resolve', promise);
+    this.one('didLoad', this, function() {
+      run(this, 'resolve', this);
     });
 
-    this.one('becameError', function() {
-      run(this, 'reject', promise);
+    this.one('becameError', this, function() {
+      run(this, 'reject', this);
     });
 
     if (get(this, 'isLoaded')) {


### PR DESCRIPTION
The record needs to resolve/reject to itself, not to its promise.
