### PR TITLE
Promisify fixtures

### DIFF
--- a/packages/ember-data/tests/integration/fixture_adapter_test.js
+++ b/packages/ember-data/tests/integration/fixture_adapter_test.js
@@ -211,3 +211,16 @@ test("polymorphic belongs to", function () {
   equal(bob.get('name'), "Bob", 'correct owner');
   equal(bob.constructor, App.Admin, 'correct person subclass');
 });
+
+test("Attempting to find a record not found in the fixtures", function() {
+  stop();
+  var person = store.find(App.Person, "not-found");
+
+  person.then(function() {
+    start();
+    ok(false);
+  }, function(record) {
+    start();
+    equal(person, record, "should error");
+  });
+});


### PR DESCRIPTION
This is an initial attempt at making fixture adapter use promises.

**Two things we need to decide:**
### How to handle Ember.assert inside the fixture adapter.

  I think they are not related to application runtime exceptions, more of a development error, so I decided to keep them out of the promise (so they don't silently turn into rejections).  I think development errors should be loud and interrupting.
### There should be a kind of pre-decided protocol for rejection reasons between the store and adapters.

  The store shouldn't get an `xhr` rejection as a reason, because then we would be tying application logic to adapter logic.  IMO both the fixture and rest adapter (and any other adapter) should return the same rejection format, such as 404 (for record not found)..etc
